### PR TITLE
Do not render the vertical time line in case there are no time line elements.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -33,42 +33,53 @@ const clean = () => {
 const replaceStandalone = () => replace(' (standalone)', '');
 
 const copyWebModelerFiles = () =>
-    gulp.src([
-        path.join(tmpContainerFolder, `${fileNameContainer}.webmodeler.js`),
-        path.join(tmpElementFolder, `${fileNameElement}.webmodeler.js`)
-    ]).pipe(gulp.dest(tmpFolder)).on("error", console.error);
+    {
+        return gulp.src([
+            path.join(tmpContainerFolder, `${fileNameContainer}.webmodeler.js`),
+            path.join(tmpElementFolder, `${fileNameElement}.webmodeler.js`)
+        ]).pipe(gulp.dest(tmpFolder)).on("error", console.error);
+    }
+   
 
-const copyContainerXML = () =>
-    gulp.src(
-        path.join(tmpContainerFolder, `${fileNameContainer}.xml`)
-    ).pipe(replaceStandalone()).pipe(
-        replace('mendix.timelinecontainer.TimelineContainer', `mendix.${mainPKGName}.TimelineContainer`)
-    ).pipe(gulp.dest(tmpFolder)).on("error", console.error);
+const copyContainerXML = () => {
+        return gulp.src(
+            path.join(tmpContainerFolder, `${fileNameContainer}.xml`)
+        ).pipe(replaceStandalone()).pipe(
+            replace('mendix.timelinecontainer.TimelineContainer', `mendix.${mainPKGName}.TimelineContainer`)
+        ).pipe(gulp.dest(tmpFolder)).on("error", console.error);   
+}
 
-const copyElementXML = () =>
-    gulp.src(
-        path.join(tmpElementFolder, `${fileNameElement}.xml`)
-    ).pipe(replaceStandalone()).pipe(
-        replace('mendix.timelineelement.TimelineElement', `mendix.${mainPKGName}.TimelineElement`)
-    ).pipe(gulp.dest(tmpFolder)).on("error", console.error);
+const copyElementXML = () => {
+        return gulp.src(
+                path.join(tmpElementFolder, `${fileNameElement}.xml`)
+            ).pipe(replaceStandalone()).pipe(
+                replace('mendix.timelineelement.TimelineElement', `mendix.${mainPKGName}.TimelineElement`)
+            ).pipe(gulp.dest(tmpFolder)).on("error", console.error);
+    }    
 
-const copyContainerCSSFiles = () =>
-    gulp.src([
-        path.join(tmpContainerFolder, `mendix/timelinecontainer/ui/${fileNameContainer}.css`),
-        // path.join(tmpContainerFolder, `mendix/timelinecontainer/ui/${fileNameContainer}.css.map`),
-    ]).pipe(gulp.dest(path.join(dstFolder, "ui"))).on("error", console.error);
+const copyContainerCSSFiles = () => {
+        return gulp.src([
+            path.join(tmpContainerFolder, `mendix/timelinecontainer/ui/${fileNameContainer}.css`),
+            // path.join(tmpContainerFolder, `mendix/timelinecontainer/ui/${fileNameContainer}.css.map`),
+        ]).pipe(gulp.dest(path.join(dstFolder, "ui"))).on("error", console.error);
+}
+    
 
-const copyWidgetFiles = () =>
-    gulp.src([
+const copyWidgetFiles = () => {
+    return gulp.src([
         path.join(tmpContainerFolder, `mendix/timelinecontainer/${fileNameContainer}.js`),
         path.join(tmpElementFolder, `mendix/timelineelement/${fileNameElement}.js`),
     ]).pipe(gulp.dest(dstFolder)).on("error", console.error);
+}
+   
 
-const copyPackageXML = () =>
-    gulp
+const copyPackageXML = () => {
+        return gulp
         .src(path.join(__dirname, "package.xml"))
         .pipe(replace("XXX", pkg.version))
     .pipe(gulp.dest(tmpFolder)).on("error", console.error);
+}
+   
 
 const zipPackage = () =>
     gulp.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mendix-timeline-widgets",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/widgets/container/src/TimelineContainer.tsx
+++ b/widgets/container/src/TimelineContainer.tsx
@@ -14,6 +14,10 @@ class TimelineContainer extends Component<TimelineContainerContainerProps> {
             return null;
         }
 
+        if (dataSource.items && dataSource.items.length === 0) {
+            return null;
+        }
+
         return (
             <VerticalTimeline
                 className={this.props.class}


### PR DESCRIPTION
1) When there are no elements in the timeline it still rendered the vertical line. Not sure this is the best solution, but I tested it and it does work.

2) I had to change the gulp code to make it work with Gulp 4. Not sure what the standard is these days.

